### PR TITLE
feat: add lon/lat to the traffic radars

### DIFF
--- a/adapters/egov-adapter-traffic-radars/.gitignore
+++ b/adapters/egov-adapter-traffic-radars/.gitignore
@@ -18,6 +18,7 @@ var/
 
 # Serverless directories
 .serverless
+.requirements.zip
 
 # Other
 __pycache__

--- a/adapters/egov-adapter-traffic-radars/README.md
+++ b/adapters/egov-adapter-traffic-radars/README.md
@@ -79,6 +79,16 @@ serverless deploy
 
 # Restrictions found so far
 
+## Max function size (50 MB)
+
+With serverless, "Request must be smaller than 69905067 bytes for the UpdateFunctionCode operation".
+This is a restriction in functions with many third-party dependencies. The serverless plugin "serverless-python-requirements" comes with some handy features to deal with it.
+
+You can zip and upload it to S3. In this case the limit is 250MB.
+Packages suck as numpy, pandas, etc are quite big and often hit this limit.
+
+## API Gateway timeout (30 seconds)
+
 The Amazon API Gateway imposes a timeout of 30 seconds.
 
 This means that you need to gather the data, process it and send a HTTP response in less than 30 seconds.

--- a/adapters/egov-adapter-traffic-radars/cloud.py
+++ b/adapters/egov-adapter-traffic-radars/cloud.py
@@ -16,6 +16,9 @@ def upload(data):
             CreateBucketConfiguration={ "LocationConstraint": REGION })
     except client.exceptions.BucketAlreadyOwnedByYou:
         pass
+    except client.exceptions.BucketAlreadyExists:
+        print("BucketAlreadyExists: review your AWS credentials")
+        raise
 
     client.put_object(
         Bucket=BUCKET,

--- a/adapters/egov-adapter-traffic-radars/geoutils.py
+++ b/adapters/egov-adapter-traffic-radars/geoutils.py
@@ -1,0 +1,108 @@
+import urllib
+import json
+import os
+import functools
+from utils import timeit
+
+POINTS_URL="https://opendata.arcgis.com/datasets/d8854f26fd5c4baab08337ca0f3aff6f_0.geojson"
+
+
+@timeit
+def _download_kilometer_points():
+    # XXX it is downloaded every time (>30 sec), we could store it somehow (S3, etc)
+    # Downloading it to the repo might be an option but:
+    # - we would miss updates to the dataset
+    # - we would exceed the 250MB allowed per AWS Lambda function
+    #
+    # Such a big file (~50MB), requires around 400MB RSS memory
+    file = urllib.request.urlopen(POINTS_URL)
+    data = file.read().decode("utf-8")
+    geofeatures = json.loads(data)["features"]
+
+    # attempt to reduce size
+    for feature in geofeatures:
+        del feature["type"]
+        del feature["properties"]["OBJECTID"]
+        del feature["properties"]["id_porpk"]
+        del feature["properties"]["id_tramo"]
+        del feature["properties"]["id_vial"]
+        del feature["properties"]["sentidopkD"]
+        del feature["properties"]["fuente"]
+        del feature["properties"]["fuenteD"]
+        del feature["geometry"]["type"]
+    return geofeatures
+
+geofeatures = []
+
+@functools.lru_cache(maxsize=64)
+def _road_pks(normalizedRoadName):
+    if not geofeatures:
+        geofeatures = _download_kilometer_points()
+
+    # Example
+    #
+    # {
+    #    'type': 'Feature',
+    #    'properties': {
+    #        'OBJECTID': 2001,
+    #        'id_porpk': 360430069577,
+    #        'id_tramo': 360430002649,
+    #        'id_vial': 612000060007,
+    #        'numero': 2,
+    #        'sentidopk': 3,
+    #        'sentidopkD': 'Ambos sentidos',
+    #        'fuente': 26,
+    #        'fuenteD': 'DGT',
+    #        'Nombre': 'EP-0208'
+    #    },
+    #    'geometry': {
+    #        'type': 'Point',
+    #        'coordinates': [-8.51971123422805, 42.35020761539828]
+    #    }
+    # }
+    #
+    pks = [{
+            "number": pk["properties"]["numero"],
+            "coordinates": pk["geometry"]["coordinates"],
+            "sense": pk["properties"]["sentidopk"]  # 3 == both senses, 2 decreasing, 1 increasing
+           }
+           for pk in geofeatures if pk["properties"]["Nombre"].upper() == normalizedRoadName]
+
+    return sorted(pks, key=lambda k: k["number"])
+
+
+def geolocate(roadName, number):
+    """
+    Geolocates a kilometer point (number) in a given road name.
+    Returns an array containing the latitude and longitude.
+    """
+    pks = _road_pks(normalize_road_name(roadName))
+    if not pks:
+        return None
+
+    result = min(pks, key=lambda k: abs(k["number"] - number))  # closest available number
+    return result["coordinates"]
+
+
+ROAD_NAMES={
+    "N-I": "N-1",
+    "N-II": "N-2",
+    "N-IIA": "N-2A",
+    "N-IIE": "N-2E",
+    "N-III": "N-3",
+    "N-IIIA": "N-3A",
+    "N-IV": "N-4",
+    "N-IVA": "N-4A",
+    "N-VA": "N-5A",
+    "N-VI": "N-6",
+    "N-121-A": "N-121A",
+    "N-121-B": "N-121B",
+    "N-121-C": "N-121C"
+}
+
+def normalize_road_name(roadName):
+    """
+    Converts the road names provided by the DGT in road names used in the IGN dataset.
+    """
+    # XXX  a lot of room for improvement here
+    return ROAD_NAMES.get(roadName.upper(), roadName.upper())

--- a/adapters/egov-adapter-traffic-radars/handler.py
+++ b/adapters/egov-adapter-traffic-radars/handler.py
@@ -2,6 +2,13 @@ from scraper import scrape
 from cloud import upload, temporal_url
 
 
+# see https://www.npmjs.com/package/serverless-python-requirements#dealing-with-lambdas-size-limitations
+try:
+  import unzip_requirements
+except ImportError:
+  pass
+
+
 def scheduled_scrape(event, context):
     data = scrape()
     upload(data)

--- a/adapters/egov-adapter-traffic-radars/package-lock.json
+++ b/adapters/egov-adapter-traffic-radars/package-lock.json
@@ -1,9 +1,14 @@
 {
-  "name": "serverless",
+  "name": "egov-adapter-traffic-radars",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@iarna/toml": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.3.tgz",
+      "integrity": "sha512-FmuxfCuolpLl0AnQ2NHSzoUKWEJDFl63qXjzdoWBVyFCXzMGm1spBzk7LeHNoVCiWCF7mRVms9e6jEV9+MoPbg=="
+    },
     "appdirectory": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/appdirectory/-/appdirectory-0.1.0.tgz",
@@ -176,11 +181,6 @@
       "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-4.3.0.tgz",
       "integrity": "sha1-o6bCsOvsxcLLocF+bmIP6BtT00c="
     },
-    "md5-file": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/md5-file/-/md5-file-4.0.0.tgz",
-      "integrity": "sha512-UC0qFwyAjn4YdPpKaDNw6gNxRf7Mcx7jC1UGCY4boCzgvU2Aoc1mOGzTtrjjLKhM5ivsnhoKpQVxKPp+1j1qwg=="
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -245,10 +245,10 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "serverless-python-requirements": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/serverless-python-requirements/-/serverless-python-requirements-4.3.0.tgz",
-      "integrity": "sha512-VyXdEKNxUWoQDbssWZeR5YMaTDf1U4CO3yJH2953Y2Rt8zD6hG+vpTkVR490/Ws1PQsBopWuFfgDcLyvAppaRg==",
+      "version": "github:UnitedIncome/serverless-python-requirements#6b5e0e25fcf022e56a2ee15505794e05128efa1e",
+      "from": "github:UnitedIncome/serverless-python-requirements#6b5e0e2",
       "requires": {
+        "@iarna/toml": "^2.2.3",
         "appdirectory": "^0.1.0",
         "bluebird": "^3.0.6",
         "fs-extra": "^7.0.0",
@@ -259,8 +259,8 @@
         "lodash.set": "^4.3.2",
         "lodash.uniqby": "^4.0.0",
         "lodash.values": "^4.3.0",
-        "md5-file": "^4.0.0",
         "rimraf": "^2.6.2",
+        "sha256-file": "1.0.0",
         "shell-quote": "^1.6.1"
       }
     },
@@ -268,6 +268,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+    },
+    "sha256-file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/sha256-file/-/sha256-file-1.0.0.tgz",
+      "integrity": "sha512-nqf+g0veqgQAkDx0U2y2Tn2KWyADuuludZTw9A7J3D+61rKlIIl9V5TS4mfnwKuXZOH9B7fQyjYJ9pKRHIsAyg=="
     },
     "shell-quote": {
       "version": "1.6.1",

--- a/adapters/egov-adapter-traffic-radars/package.json
+++ b/adapters/egov-adapter-traffic-radars/package.json
@@ -18,6 +18,6 @@
   ],
   "license": "AGPL-3.0-or-later",
   "dependencies": {
-    "serverless-python-requirements": "^4.3.0"
+    "serverless-python-requirements": "UnitedIncome/serverless-python-requirements#6b5e0e2"
   }
 }

--- a/adapters/egov-adapter-traffic-radars/scraper_cat.py
+++ b/adapters/egov-adapter-traffic-radars/scraper_cat.py
@@ -3,6 +3,7 @@ import re
 
 from datetime import datetime
 from utils import timeit
+from geoutils import geolocate
 
 BASE_URL = "http://transit.gencat.cat/ca/seguretat_viaria/cinemometre_fixos_mobils_catalunya/"
 
@@ -68,8 +69,6 @@ def scrape():
         BASE_URL,
         header=0)
 
-    print(len(tables))
-
     if len(tables) != 3:  # fixed, mobile, stretch
         raise Exception("Unexpected data found in the source document")
 
@@ -83,8 +82,15 @@ def scrape():
     radars.extend(stretch)
     radars.extend(mobile)
 
-    return radars
+    # XXX pythonize this code
+    for radar in radars:
+        if radar["kilometers"]:
+            location = geolocate(radar["roadName"], radar["kilometers"][0])
+            if location:
+                radar["longitude"] = location[0]
+                radar["latitude"] = location[1]
 
+    return radars
 
 
 ADMIN_NAMES={

--- a/adapters/egov-adapter-traffic-radars/scraper_eus.py
+++ b/adapters/egov-adapter-traffic-radars/scraper_eus.py
@@ -2,6 +2,7 @@ import pandas as pd
 
 from datetime import datetime
 from utils import timeit
+from geoutils import geolocate
 
 BASE_URL = "https://www.trafikoa.eus/wps/portal/trafico/!ut/p/z0/04_Sj9CPykssy0xPLMnMz0vMAfIjo8ziXTycTI2CzdwsLU2cvVwNXFzdjQwgQD84tVi_INtREQACSLYJ/"
 
@@ -20,6 +21,11 @@ def table_to_radars(table):
             "kilometers": [ float(row.values[1]) ],
             "updatedAt": datetime.now().replace(microsecond=0).isoformat()
         }
+
+        location = geolocate(radar["roadName"], radar["kilometers"][0])
+        if location:
+            radar["longitude"] = location[0]
+            radar["latitude"] = location[1]
 
         try:
             radar["maxSpeed"] = int(row.values[5].split()[0])

--- a/adapters/egov-adapter-traffic-radars/serverless.yml
+++ b/adapters/egov-adapter-traffic-radars/serverless.yml
@@ -1,10 +1,27 @@
 service: egov-adapter-traffic-radars
 
+frameworkVersion: ">=1.34.0" # Layers are supported from version 1.34
+
 custom:
   bucket: egov-adapter-traffic-radars
   region: eu-west-1
   pythonRequirements:
     dockerizePip: non-linux
+    zip: true
+    slim: true
+    slimPatterns:
+      - "cv2/data/*.xml"
+      - "**/tests"
+    strip: false  # workaround for this issue https://github.com/UnitedIncome/serverless-python-requirements/issues/318
+    layer:
+      name: ${self:service}-python-requirements
+      description: Python requirements lambda layer
+      compatibleRuntimes:
+        - python3.6
+        - python3.7
+      licenseInfo: AGPLv3
+      allowedAccounts:
+        - '*'
 
 provider:
   name: aws
@@ -31,9 +48,11 @@ provider:
 
 functions:
   scrape:
-    timeout: 120
+    timeout: 150
     memorySize: 3008
     handler: handler.scheduled_scrape
+    layers:
+      - {Ref: PythonRequirementsLambdaLayer}
     events:
       - schedule:
           name: egov-adapter-traffic-radars-scrape
@@ -43,6 +62,8 @@ functions:
     timeout: 5
     memorySize: 256
     handler: handler.adapt
+    layers:
+      - {Ref: PythonRequirementsLambdaLayer}
     events:
       - http:
           path: "{proxy+}"

--- a/docs/datasets.html
+++ b/docs/datasets.html
@@ -201,10 +201,10 @@
 								</span>
 							</p>
 							<p>
-								<h3>Códigos postales y municipios</h3>
+								<h3>Radares de tráfico</h3>
 								<div class="label label-success">tráfico</div>
 								<div class="label label-success">poi</div>
-								<span class="icon" title="Fuente: DGT, Trafiko Zuzendaritza, Servei Català de Trànsit">
+								<span class="icon" title="Fuentes: Dirección General de Tráfico, Trafiko Zuzendaritza, Servei Català de Trànsit, Instituto Geográfico Nacional">
 									<i class="icon-info"></i>
 								</span>
 								<span class="small text-muted">

--- a/packages/egov-api-server/assets/schema.graphql
+++ b/packages/egov-api-server/assets/schema.graphql
@@ -156,6 +156,20 @@ type TrafficRadar {
   sense: TrafficRadarSense!
 
   """
+  Longitude in degrees (wgs84) where the radar is located.
+  Available when the kilometer in the road is known.
+  Still not very accurate in radars with BOTH senses.
+  """
+  longitude: Float
+
+  """
+  Latitude in degrees (wgs84) where the radar is located.
+  Available when the kilometer in the road is known.
+  Still not very accurate in radars with BOTH senses.
+  """
+  latitude: Float
+
+  """
   The point in the road in kilometers.
   A radar can have up to two locations, one per sense in the road.
   These locations must be translated into geographical coordinates in the future.

--- a/packages/egov-api-server/src/index.ts
+++ b/packages/egov-api-server/src/index.ts
@@ -9,6 +9,7 @@ import * as path from 'path';
 
 import { DataSource } from 'apollo-datasource';
 import { ApolloServer, gql } from 'apollo-server';
+import { GraphQLFormattedError } from 'graphql';
 
 // XXX use a schema validator at lint time https://github.com/cjoudrey/graphql-schema-linter
 const schema = fs.readFileSync(path.join(__dirname, 'schema.graphql')).toString();
@@ -66,6 +67,12 @@ const server = new ApolloServer({
     postalCodeService: new egov.PostalCodeService() as DataSource<any>,
     trafficRadarService: new egov.TrafficRadarService() as DataSource<any>
   }),
+  formatError: error => {
+    logops.error(error);
+    return {
+      message: 'Internal Server Error. Report it to help us fix the issue.'
+    } as GraphQLFormattedError;
+  },
   resolvers,
   tracing: process.env.NODE_ENV === 'development',
   typeDefs

--- a/packages/egov-data-providers/src/providers/traffic/index.ts
+++ b/packages/egov-data-providers/src/providers/traffic/index.ts
@@ -6,7 +6,9 @@ export type TrafficRadar = {
   type: string; // XXX enum
   sense: string; // XXX enum
   kilometers: [number];
-  maxSpeed: number;
+  maxSpeed?: number;
+  longitude?: number;
+  latitude?: number;
 };
 
 interface ITrafficRadarService {


### PR DESCRIPTION
Añade datos de longitud y latitud a algunos radares (aquellos que tienen punto kilométrico), combinándolos con el dataset https://opendata.esri.es/datasets/d8854f26fd5c4baab08337ca0f3aff6f_0 el IGN.

Hay carreteras cuyo nombre difiere entre los datos de la DGT y algunos radares que no tienen punto kilométrico conocido, por lo que algunos radares no tendrán ubicación geográfica aún

El código es parte del adaptador Python que es una prueba de concepto, francamente optimizable. Se agradecen las contribuciones de alguien que sepa más Python que yo.